### PR TITLE
Fix duplicate field in Position model

### DIFF
--- a/app/Models/Position.php
+++ b/app/Models/Position.php
@@ -32,7 +32,6 @@ class Position extends Model
             'working_conditions',
             'working_equipments',
             'other',
-            'is_active'
         ];
 
     public function employees()


### PR DESCRIPTION
## Summary
- remove redundant `is_active` entry from the `Position` model's `$fillable` array

## Testing
- `composer test` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68482c7c7bbc8324a34a10fa1e0548ef